### PR TITLE
[FEAT] 비디오 플레이 화면 기본 구현 완료

### DIFF
--- a/app/src/main/java/com/preonboarding/videorecorder/presentation/play/PlayFragment.kt
+++ b/app/src/main/java/com/preonboarding/videorecorder/presentation/play/PlayFragment.kt
@@ -1,6 +1,5 @@
 package com.preonboarding.videorecorder.presentation.play
 
-import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.activityViewModels
@@ -23,16 +22,22 @@ import kotlinx.coroutines.launch
 @AndroidEntryPoint
 class PlayFragment : BaseFragment<FragmentPlayBinding>(R.layout.fragment_play) {
     private val playVideoModel: MainViewModel by activityViewModels()
-    private val navArgs: PlayFragmentArgs by navArgs()
 
+    //TODO 영화목록 연결할 때 아래 주석 해제하기
+    private val navArgs: PlayFragmentArgs by navArgs()
+    //private var uri: String = ""
+
+    //TODO 영화목록 연결할 때 테스트용인 아래 세문장 지우기
     private val testUri =
         "https://www.learningcontainer.com/wp-content/uploads/2020/05/sample-mp4-file.mp4"
     private val testVideo = Video("", testUri)
     private var uri: String = testUri
+
     private var exoPlayer: ExoPlayer? = null
     private var exoPlayWhenReady = true
     private var exoCurrentWindow = 0
     private var exoPlaybackPosition = 0L
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.fragment = this@PlayFragment
@@ -55,15 +60,15 @@ class PlayFragment : BaseFragment<FragmentPlayBinding>(R.layout.fragment_play) {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 playVideoModel.selectedVideo.collect { video ->
                     uri = video.uri
-                    setExoPlayer()
                 }
             }
         }
     }
 
     private fun getSelectedVideo() {
+        //TODO 영화목록 연결 시 아래 주석해제하고 테스트용 문장 지우기
         //playVideoModel.setSelectedVideo(navArgs.video)
-        playVideoModel.setSelectedVideo(testVideo)
+        playVideoModel.setSelectedVideo(testVideo) //테스트용
         collectFlow()
     }
 
@@ -79,6 +84,20 @@ class PlayFragment : BaseFragment<FragmentPlayBinding>(R.layout.fragment_play) {
             release()
         }
         exoPlayer = null
+    }
+
+    override fun onStart() {
+        super.onStart()
+        if (Util.SDK_INT >= 24) {
+            setExoPlayer()
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if ((Util.SDK_INT < 24 || exoPlayer == null)) {
+            setExoPlayer()
+        }
     }
 
     override fun onPause() {

--- a/app/src/main/java/com/preonboarding/videorecorder/presentation/play/PlayFragment.kt
+++ b/app/src/main/java/com/preonboarding/videorecorder/presentation/play/PlayFragment.kt
@@ -1,5 +1,6 @@
 package com.preonboarding.videorecorder.presentation.play
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.activityViewModels
@@ -8,8 +9,12 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.findNavController
 import androidx.navigation.fragment.navArgs
+import com.google.android.exoplayer2.ExoPlayer
+import com.google.android.exoplayer2.MediaItem
+import com.google.android.exoplayer2.util.Util
 import com.preonboarding.videorecorder.R
 import com.preonboarding.videorecorder.databinding.FragmentPlayBinding
+import com.preonboarding.videorecorder.domain.model.Video
 import com.preonboarding.videorecorder.presentation.MainViewModel
 import com.preonboarding.videorecorder.presentation.base.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
@@ -20,21 +25,28 @@ class PlayFragment : BaseFragment<FragmentPlayBinding>(R.layout.fragment_play) {
     private val playVideoModel: MainViewModel by activityViewModels()
     private val navArgs: PlayFragmentArgs by navArgs()
 
+    private val testUri =
+        "https://www.learningcontainer.com/wp-content/uploads/2020/05/sample-mp4-file.mp4"
+    private val testVideo = Video("", testUri)
+    private var uri: String = testUri
+    private var exoPlayer: ExoPlayer? = null
+    private var exoPlayWhenReady = true
+    private var exoCurrentWindow = 0
+    private var exoPlaybackPosition = 0L
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        // 선택된 비디오 세팅
-        //getSelectedVideo()
-        collectFlow()
-        initView()
+        binding.fragment = this@PlayFragment
+        getSelectedVideo()
     }
 
-    private fun initView() {
-        binding.apply {
-            // TODO 네비게이션 설정 되면 붙히세요
-            // 안그러면 터집니다.
-            /*ivPlayBack.setOnClickListener {
-                requireView().findNavController().popBackStack()
-            }*/
+    private fun setExoPlayer() {
+        val mediaItem = MediaItem.fromUri(uri)
+        exoPlayer = ExoPlayer.Builder(requireContext()).build().also {
+            binding.pvPlayVideo.player = it
+            it.setMediaItem(mediaItem)
+            it.playWhenReady = exoPlayWhenReady
+            it.seekTo(exoCurrentWindow, exoPlaybackPosition)
+            it.prepare()
         }
     }
 
@@ -42,13 +54,44 @@ class PlayFragment : BaseFragment<FragmentPlayBinding>(R.layout.fragment_play) {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 playVideoModel.selectedVideo.collect { video ->
-                    // TODO 선택된 비디오 ExoPlayer와 작업 필요
+                    uri = video.uri
+                    setExoPlayer()
                 }
             }
         }
     }
 
     private fun getSelectedVideo() {
-        playVideoModel.setSelectedVideo(navArgs.video)
+        //playVideoModel.setSelectedVideo(navArgs.video)
+        playVideoModel.setSelectedVideo(testVideo)
+        collectFlow()
+    }
+
+    fun setBackButton(view: View) {
+        requireView().findNavController().popBackStack()
+    }
+
+    private fun releasePlayer() {
+        exoPlayer?.run {
+            exoPlaybackPosition = this.currentPosition
+            exoCurrentWindow = this.currentMediaItemIndex
+            exoPlayWhenReady = this.playWhenReady
+            release()
+        }
+        exoPlayer = null
+    }
+
+    override fun onPause() {
+        super.onPause()
+        if (Util.SDK_INT < 24) {
+            releasePlayer()
+        }
+    }
+
+    override fun onStop() {
+        super.onStop()
+        if (Util.SDK_INT >= 24) {
+            releasePlayer()
+        }
     }
 }

--- a/app/src/main/java/com/preonboarding/videorecorder/presentation/play/adapter/PlayBindingAdapter.kt
+++ b/app/src/main/java/com/preonboarding/videorecorder/presentation/play/adapter/PlayBindingAdapter.kt
@@ -1,1 +1,5 @@
 package com.preonboarding.videorecorder.presentation.play.adapter
+
+object PlayBindingAdapter {
+
+}

--- a/app/src/main/res/layout/fragment_play.xml
+++ b/app/src/main/res/layout/fragment_play.xml
@@ -4,7 +4,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
-
+        <variable
+            name="fragment"
+            type="com.preonboarding.videorecorder.presentation.play.PlayFragment" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -12,6 +14,7 @@
         android:layout_height="match_parent">
 
         <ImageView
+            android:onClick="@{fragment::setBackButton}"
             android:id="@+id/iv_play_back"
             android:layout_width="30dp"
             android:layout_height="30dp"
@@ -22,11 +25,11 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-            android:id="@+id/textView2"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="플레이화면 입니다."
+        <com.google.android.exoplayer2.ui.PlayerView
+            android:id="@+id/pv_play_video"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:show_timeout="3000"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/navigation/video_navigation.xml
+++ b/app/src/main/res/navigation/video_navigation.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/video_navigation"
-    app:startDestination="@id/listFragment">
+    app:startDestination="@id/playFragment">
 
     <fragment
         android:id="@+id/listFragment"


### PR DESCRIPTION
## 🔑요약
***
video_navigation.xml 부분 startdestination을 비디오 재생화면으로 해놔서 머지할 때 목록화면으로 수정 필요합니다
***
- 그 외에는 머지할 때 TODO 부분 따라주시면 됩니다!
- 녹화된 영상 플레이 구현
- 화면 하단 컨트롤 바 구현 (재생, 일시정지, 플레이 seekbar)

## 🗂️작업사항
- 앱이 백그라운드로 내려가면 멈추고 정보를 간직
- 포그라운드로 돌아왔을 때 해당 정보부터 다시 재생

## 💻결과
https://user-images.githubusercontent.com/35549958/196950489-c0e50431-25f5-4097-b162-cbf3f27c6e18.mp4


## ❗TODO
- 컨트롤 바 커스텀 해보기
- 전체화면 기능 추가해보기
